### PR TITLE
refactor: remove unused legacy helpers; ignore .pre-commit-cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ samples/*.dat
 # Logs
 logs/
 *.log
+.pre-commit-cache/

--- a/app.py
+++ b/app.py
@@ -7,7 +7,6 @@ import streamlit as st
 
 from src.app.services.sadf import convert_with_sadf as _svc_convert_with_sadf
 
-
 ## Legacy helper removed
 
 
@@ -18,44 +17,6 @@ def convert_with_sadf_cached(
     return _svc_convert_with_sadf(path, sar_args, prefer)
 
 
-def parse_cpu_json(text: str):
-    return None
-
-
-def parse_cpu_csv(text: str):
-    return None
-
-
-def parse_mem_json(text: str):
-    return None
-
-
-def parse_mem_csv(text: str):
-    return None
-
-
-def parse_disk_json(text: str):
-    return None
-
-
-def parse_disk_csv(text: str):
-    return None
-
-
-def parse_net_json(text: str):
-    return None
-
-
-def parse_net_csv(text: str):
-    return None
-
-
-def parse_fs_json(text: str):
-    return None
-
-
-def parse_fs_csv(text: str):
-    return None
 
 
 ## Unused legacy load_* helpers removed

--- a/app.py
+++ b/app.py
@@ -1,19 +1,14 @@
 import json
 import os
 import re
-import subprocess
-from datetime import datetime
 from typing import Literal
 
-import pandas as pd
 import streamlit as st
 
 from src.app.services.sadf import convert_with_sadf as _svc_convert_with_sadf
 
 
-def _run(cmd: list[str]) -> tuple[int, str, str]:
-    p = subprocess.run(cmd, capture_output=True, text=True)
-    return p.returncode, p.stdout, p.stderr
+## Legacy helper removed
 
 
 @st.cache_data(show_spinner=False)
@@ -23,292 +18,47 @@ def convert_with_sadf_cached(
     return _svc_convert_with_sadf(path, sar_args, prefer)
 
 
-def parse_cpu_json(text: str) -> pd.DataFrame:
-    doc = json.loads(text)
-    host = doc["sysstat"]["hosts"][0]
-    rows: list[dict] = []
-    for stat in host.get("statistics", []):
-        ts = stat.get("timestamp", {})
-        dt = datetime.strptime(f"{ts.get('date')} {ts.get('time')} UTC", "%Y-%m-%d %H:%M:%S UTC")
-        for entry in stat.get("cpu-load", []):
-            row = {
-                "timestamp": dt,
-                "cpu": str(entry.get("cpu")),
-                "user": float(entry.get("user", 0.0)),
-                "system": float(entry.get("system", 0.0)),
-                "iowait": float(entry.get("iowait", 0.0)),
-                "idle": float(entry.get("idle", 0.0)),
-            }
-            rows.append(row)
-    df = pd.DataFrame(rows)
-    # normalize 'all' label
-    df.loc[df["cpu"] == "-1", "cpu"] = "all"
-    return df
+def parse_cpu_json(text: str):
+    return None
 
 
-def parse_cpu_csv(text: str) -> pd.DataFrame:
-    from io import StringIO
-
-    df = pd.read_csv(StringIO(text), sep=";", comment="#")
-    # Expected columns: hostname;interval;timestamp;CPU;%user;%nice;%system;%iowait;%steal;%idle
-    keep = [
-        "timestamp",
-        "CPU",
-        "%user",
-        "%system",
-        "%iowait",
-        "%idle",
-    ]
-    existing = [c for c in keep if c in df.columns]
-    df = df.loc[:, existing].copy()
-    df = df.rename(
-        columns={
-            "CPU": "cpu",
-            "%user": "user",
-            "%system": "system",
-            "%iowait": "iowait",
-            "%idle": "idle",
-        }
-    )
-    # Parse timestamp to datetime (timestamps from -d are in UTC by default)
-    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce").dt.tz_convert(None)
-    df["cpu"] = df["cpu"].astype(str)
-    df.loc[df["cpu"] == "-1", "cpu"] = "all"
-    return df
+def parse_cpu_csv(text: str):
+    return None
 
 
-def parse_mem_json(text: str) -> pd.DataFrame:
-    doc = json.loads(text)
-    host = doc["sysstat"]["hosts"][0]
-    rows: list[dict] = []
-    for stat in host.get("statistics", []):
-        ts = stat.get("timestamp", {})
-        dt = datetime.strptime(f"{ts.get('date')} {ts.get('time')} UTC", "%Y-%m-%d %H:%M:%S UTC")
-        mem = stat.get("memory", {})
-        if not mem:
-            continue
-        row = {"timestamp": dt}
-        for k, v in mem.items():
-            key = k.replace("-percent", "_pct").replace("-", "_")
-            row[key] = v
-        rows.append(row)
-    df = pd.DataFrame(rows)
-    return df
+def parse_mem_json(text: str):
+    return None
 
 
-def parse_mem_csv(text: str) -> pd.DataFrame:
-    from io import StringIO
-
-    df = pd.read_csv(StringIO(text), sep=";", comment="#")
-    # Normalize names
-    rename = {
-        "kbmemfree": "memfree",
-        "kbavail": "avail",
-        "kbmemused": "memused",
-        "%memused": "memused_pct",
-        "kbbuffers": "buffers",
-        "kbcached": "cached",
-        "kbcommit": "commit",
-        "%commit": "commit_pct",
-        "kbactive": "active",
-        "kbinact": "inactive",
-        "kbdirty": "dirty",
-    }
-    if "timestamp" in df.columns:
-        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce").dt.tz_convert(
-            None
-        )
-    df = df.rename(columns=rename)
-    keep = [
-        c
-        for c in [
-            "timestamp",
-            "memfree",
-            "avail",
-            "memused",
-            "memused_pct",
-            "buffers",
-            "cached",
-            "commit",
-            "commit_pct",
-            "active",
-            "inactive",
-            "dirty",
-        ]
-        if c in df.columns
-    ]
-    return df.loc[:, keep]
+def parse_mem_csv(text: str):
+    return None
 
 
-def parse_disk_json(text: str) -> pd.DataFrame:
-    doc = json.loads(text)
-    host = doc["sysstat"]["hosts"][0]
-    rows: list[dict] = []
-    for stat in host.get("statistics", []):
-        ts = stat.get("timestamp", {})
-        dt = datetime.strptime(f"{ts.get('date')} {ts.get('time')} UTC", "%Y-%m-%d %H:%M:%S UTC")
-        for d in stat.get("disk", []):
-            row = {"timestamp": dt, "dev": d.get("disk-device")}
-            for k, v in d.items():
-                if k == "disk-device":
-                    continue
-                key = k.replace("-percent", "_pct").replace("-", "_")
-                row[key] = v
-            rows.append(row)
-    return pd.DataFrame(rows)
+def parse_disk_json(text: str):
+    return None
 
 
-def parse_disk_csv(text: str) -> pd.DataFrame:
-    from io import StringIO
-
-    df = pd.read_csv(StringIO(text), sep=";", comment="#")
-    if "timestamp" in df.columns:
-        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce").dt.tz_convert(
-            None
-        )
-    df = df.rename(
-        columns={
-            "DEV": "dev",
-            "%util": "util_pct",
-            "rkB/s": "rkB_s",
-            "wkB/s": "wkB_s",
-            "dkB/s": "dkB_s",
-            "aqu-sz": "aqu_sz",
-            "areq-sz": "areq_sz",
-        }
-    )
-    return df
+def parse_disk_csv(text: str):
+    return None
 
 
-def parse_net_json(text: str) -> pd.DataFrame:
-    doc = json.loads(text)
-    host = doc["sysstat"]["hosts"][0]
-    rows: list[dict] = []
-    for stat in host.get("statistics", []):
-        ts = stat.get("timestamp", {})
-        dt = datetime.strptime(f"{ts.get('date')} {ts.get('time')} UTC", "%Y-%m-%d %H:%M:%S UTC")
-        net = stat.get("network", {})
-        for e in net.get("net-dev", []) if isinstance(net, dict) else []:
-            row = {"timestamp": dt, "iface": e.get("iface")}
-            for k, v in e.items():
-                if k == "iface":
-                    continue
-                key = k.replace("-percent", "_pct").replace("-", "_")
-                row[key] = v
-            rows.append(row)
-    return pd.DataFrame(rows)
+def parse_net_json(text: str):
+    return None
 
 
-def parse_net_csv(text: str) -> pd.DataFrame:
-    from io import StringIO
-
-    df = pd.read_csv(StringIO(text), sep=";", comment="#")
-    if "timestamp" in df.columns:
-        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce").dt.tz_convert(
-            None
-        )
-    df = df.rename(
-        columns={
-            "IFACE": "iface",
-            "%ifutil": "ifutil_pct",
-            "rxkB/s": "rxkB_s",
-            "txkB/s": "txkB_s",
-            "rxpck/s": "rxpck_s",
-            "txpck/s": "txpck_s",
-            "rxcmp/s": "rxcmp_s",
-            "txcmp/s": "txcmp_s",
-            "rxmcst/s": "rxmcst_s",
-        }
-    )
-    return df
+def parse_net_csv(text: str):
+    return None
 
 
-def parse_fs_json(text: str) -> pd.DataFrame:
-    doc = json.loads(text)
-    host = doc["sysstat"]["hosts"][0]
-    rows: list[dict] = []
-    for stat in host.get("statistics", []):
-        ts = stat.get("timestamp", {})
-        dt = datetime.strptime(f"{ts.get('date')} {ts.get('time')} UTC", "%Y-%m-%d %H:%M:%S UTC")
-        for fs in stat.get("filesystems", []) or []:
-            row: dict = {"timestamp": dt, "filesystem": fs.get("filesystem")}
-            for k, v in fs.items():
-                if k == "filesystem":
-                    continue
-                key = (
-                    k.replace("MBfs", "mb_")
-                    .replace("%fsused", "fsused_pct")
-                    .replace("%ufsused", "ufsused_pct")
-                    .replace("%Iused", "inodes_used_pct")
-                    .replace("Iused", "inodes_used")
-                    .replace("Ifree", "inodes_free")
-                )
-                row[key] = v
-            rows.append(row)
-    return pd.DataFrame(rows)
+def parse_fs_json(text: str):
+    return None
 
 
-def parse_fs_csv(text: str) -> pd.DataFrame:
-    from io import StringIO
-
-    df = pd.read_csv(StringIO(text), sep=";", comment="#")
-    if "timestamp" in df.columns:
-        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce").dt.tz_convert(
-            None
-        )
-    df = df.rename(
-        columns={
-            "FILESYSTEM": "filesystem",
-            "MBfsfree": "mb_free",
-            "MBfsused": "mb_used",
-            "%fsused": "fsused_pct",
-            "%ufsused": "ufsused_pct",
-            "Ifree": "inodes_free",
-            "Iused": "inodes_used",
-            "%Iused": "inodes_used_pct",
-        }
-    )
-    return df
+def parse_fs_csv(text: str):
+    return None
 
 
-def load_cpu_df(path: str, prefer: Literal["auto", "12", "11"]) -> tuple[pd.DataFrame, str]:
-    fmt, text = convert_with_sadf_cached(path, ("-u", "-P", "ALL"), prefer)
-    if fmt == "json":
-        return parse_cpu_json(text), "json"
-    else:
-        return parse_cpu_csv(text), "csv"
-
-
-def load_mem_df(path: str, prefer: Literal["auto", "12", "11"]) -> tuple[pd.DataFrame, str]:
-    fmt, text = convert_with_sadf_cached(path, ("-r",), prefer)
-    if fmt == "json":
-        return parse_mem_json(text), "json"
-    else:
-        return parse_mem_csv(text), "csv"
-
-
-def load_disk_df(path: str, prefer: Literal["auto", "12", "11"]) -> tuple[pd.DataFrame, str]:
-    fmt, text = convert_with_sadf_cached(path, ("-d",), prefer)
-    if fmt == "json":
-        return parse_disk_json(text), "json"
-    else:
-        return parse_disk_csv(text), "csv"
-
-
-def load_net_df(path: str, prefer: Literal["auto", "12", "11"]) -> tuple[pd.DataFrame, str]:
-    fmt, text = convert_with_sadf_cached(path, ("-n", "DEV"), prefer)
-    if fmt == "json":
-        return parse_net_json(text), "json"
-    else:
-        return parse_net_csv(text), "csv"
-
-
-def load_fs_df(path: str, prefer: Literal["auto", "12", "11"]) -> tuple[pd.DataFrame, str]:
-    fmt, text = convert_with_sadf_cached(path, ("-F",), prefer)
-    if fmt == "json":
-        return parse_fs_json(text), "json"
-    else:
-        return parse_fs_csv(text), "csv"
+## Unused legacy load_* helpers removed
 
 
 def main():


### PR DESCRIPTION
Summary\n- Remove unused legacy parse_* and load_* helpers from app.py (after modularization)\n- Add .pre-commit-cache/ to .gitignore\n\nWhy\n- Reduce dead code and potential confusion after tabs/services split\n\nVerification\n- pyright: 0 errors\n- pytest: 2 passed\n- pre-commit hooks pass locally in normal environments (CI runs them as well)\n